### PR TITLE
Fix for calendar not showing in the right place if the view scroll

### DIFF
--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -145,7 +145,6 @@
       >
         {label || " "}
     </label>
-  </div>
     <DateInput 
       bind:value={date} 
       on:select={e => {
@@ -170,6 +169,7 @@
     {#if fieldState?.error}
       <div class="error">{fieldState.error}</div>
     {/if}
+  </div>
   {/if}
 </div>
 

--- a/src/DateInput.svelte
+++ b/src/DateInput.svelte
@@ -182,7 +182,7 @@
   }
 </script>
 
-<div class="pickerContainer" on:focusout={onFocusOut} >
+<div class="spectrum-Form-itemField" on:focusout={onFocusOut} >
   <div class="spectrum-Textfield spectrum-Textfield-input spectrum-InputGroup-input" on:keydown={keydown}>
     <input
       class:invalid={!valid}
@@ -211,15 +211,13 @@
 </div>
 
 <style lang="sass">
-  .pickerContainer
-    height: 32px
-    overflow: visible
   .spectrum-Textfield
-    width: 100%
+    width: auto
   input
     color: var(--date-picker-foreground, #000000)
     background: var(--date-picker-background, #ffffff)
     min-width: 0px
+    width: 100%
     box-sizing: border-box
     border: none
     outline: none


### PR DESCRIPTION
This is my enhanced version of your [fix](https://github.com/melohagan/budibase-component-kasper-date-picker/commit/a5bcea4aedb02939d8d81e9fb99690a9e78d19b2) related to the issue [1612392680](https://github.com/melohagan/budibase-component-kasper-date-picker/issues/10#issue-1612392680) I opened.

The class `spectrum-Form-itemField` probably fix what you were trying to fix by adding `pickerContainer` and also is in line with Spectrum and Budibase conventions. (I don't remember where I found that class, but there is a native BB component using this pattern, probably text input?)

Sorry I had not made this pull request before, I hope you did not spend too much time on that fix... I'm working on a project for a client, so I just forked in a private repo and added stuff I needed quickly. #oops