### PR TITLE
Added padding and size styles in schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -6,6 +6,10 @@
     "friendlyName": "kasper-date-picker",
     "description": "Date picker that supports locale",
     "icon": "DateInput",
+    "styles": [
+      "padding",
+      "size"
+    ],
     "settings": [
       {
         "type": "field/datetime",


### PR DESCRIPTION
Simple one I forgot yesterday. Add basic styling options common to input components.